### PR TITLE
UDP Multicast

### DIFF
--- a/pad_server/src/telemetry.c
+++ b/pad_server/src/telemetry.c
@@ -1,3 +1,4 @@
+#include <arpa/inet.h>
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>
@@ -10,22 +11,10 @@
 
 #include "telemetry.h"
 
+#define MULTICAST_ADDR "224.0.0.10"
+
 /* Helper function for returning an error code from a thread */
 #define thread_return(e) pthread_exit((void *)(unsigned long)((e)))
-
-/* Linked list of connected clients */
-typedef struct {
-    pthread_mutex_t lock;       /* Protect concurrent access to clients. */
-    pthread_cond_t space_avail; /* Space is available for a new client */
-    unsigned int connected;     /* The number of connected clients */
-    int clients[MAX_TELEMETRY]; /* A list of client connections */
-} client_l_t;
-
-/* Arguments for the connection accepting thread */
-struct accept_args {
-    client_l_t *list; /* The list of client connections */
-    int master_sock;  /* The master socket to accept connections on. */
-};
 
 /* The main telemetry socket */
 typedef struct {
@@ -42,18 +31,13 @@ typedef struct {
 static int telemetry_init(telemetry_sock_t *sock, uint16_t port) {
 
     /* Initialize the socket connection. */
-    sock->sock = socket(AF_INET, SOCK_STREAM, 0);
+    sock->sock = socket(AF_INET, SOCK_DGRAM, 0);
     if (sock->sock < 0) return errno;
 
     /* Create address */
     sock->addr.sin_family = AF_INET;
-    sock->addr.sin_addr.s_addr = INADDR_ANY;
+    sock->addr.sin_addr.s_addr = inet_addr(MULTICAST_ADDR);
     sock->addr.sin_port = htons(port);
-
-    /* Bind the controller socket */
-    if (bind(sock->sock, (struct sockaddr *)&sock->addr, sizeof(sock->addr)) < 0) {
-        return errno;
-    }
 
     return 0;
 }
@@ -71,169 +55,24 @@ static int telemetry_close(telemetry_sock_t *sock) {
 }
 
 /*
+ * Publish a telemetry message to all listeners.
+ * @param sock The telemetry socket on which to publish.
+ * @param msg The message to send.
+ * @return 0 for success, error code on failure.
+ */
+static int telemetry_publish(telemetry_sock_t *sock, struct msghdr *msg) {
+    msg->msg_name = &sock->addr;
+    msg->msg_namelen = sizeof(sock->addr);
+    sendmsg(sock->sock, msg, MSG_NOSIGNAL);
+    return 0;
+}
+
+/*
  * pthread cleanup handler for telemetry socket.
  * @param arg A pointer to a telemetry socket.
  * @return 0 on success, error code on error.
  */
 static void telemetry_cleanup(void *arg) { telemetry_close((telemetry_sock_t *)(arg)); }
-
-/*
- * Initializes a list of clients.
- * @param l The list to initialize.
- */
-static void client_list_init(client_l_t *l) {
-    l->connected = 0;
-    // TODO: do I need to handle pthread errors
-    pthread_mutex_init(&l->lock, NULL);
-    pthread_cond_init(&l->space_avail, NULL);
-    for (unsigned int i = 0; i < MAX_TELEMETRY; i++) {
-        l->clients[i] = -1;
-    }
-}
-
-/*
- * Add a client to the list of clients.
- * @param l The list of clients to add to.
- * @param client The client to add to the list.
- * @return 0 on success, error code on failure.
- */
-static int client_list_add(client_l_t *l, int client) {
-
-    int err;
-
-    err = pthread_mutex_lock(&l->lock);
-    if (err) return err;
-
-    /* No space, don't add client */
-    while (l->connected == MAX_TELEMETRY) {
-        pthread_cond_wait(&l->space_avail, &l->lock);
-        // TODO: do I need to handle return value
-    }
-
-    /* There is space, add the client */
-    l->connected++;
-    for (unsigned int i = 0; i < MAX_TELEMETRY; i++) {
-        if (l->clients[i] == -1) {
-            l->clients[i] = client;
-            return pthread_mutex_unlock(&l->lock);
-        }
-    }
-
-    /* We should never get here, because this means the client list has recorded that there is space when there isn't
-     * any.
-     */
-    assert(0 && "Client list lied about space available.");
-    return pthread_mutex_unlock(&l->lock);
-}
-
-/*
- * Remove a client from the list.
- * @param client_id The ID of the client to remove.
- * @return 0 on success, error code on failure.
- */
-static int client_list_remove(client_l_t *l, unsigned int client_id) {
-
-    int ret;
-    int err;
-
-    assert(client_id < MAX_TELEMETRY);
-
-    err = pthread_mutex_lock(&l->lock);
-    if (err) return err;
-
-    if (close(l->clients[client_id]) < 0) {
-        ret = errno;
-    }
-    l->clients[client_id] = -1;
-    l->connected--;
-    ret = 0;
-    err = pthread_cond_signal(&l->space_avail); // Signal another client can be added
-    if (err) ret = err;
-
-    err = pthread_mutex_unlock(&l->lock);
-    if (err) return err;
-    return ret;
-}
-
-/*
- * Send a message to the client.
- * @param l The client list to use.
- * @param client_id The client to send to.
- * @param msg The message to send.
- */
-static ssize_t client_list_send(client_l_t *l, unsigned int client_id, struct msghdr *msg) {
-    assert(client_id < MAX_TELEMETRY);
-    pthread_mutex_lock(&l->lock);
-    ssize_t sent = sendmsg(l->clients[client_id], msg, MSG_NOSIGNAL);
-    pthread_mutex_unlock(&l->lock);
-    return sent;
-}
-
-static bool client_list_active(client_l_t *l, unsigned int client_id) {
-    assert(client_id < MAX_TELEMETRY);
-    pthread_mutex_lock(&l->lock);
-    bool ret = l->clients[client_id] != -1;
-    pthread_mutex_unlock(&l->lock);
-    return ret;
-}
-
-/*
- * Send a message to all active clients in the list.
- * @param l The client list to use.
- * @param msg The message to send to all active clients.
- */
-static void client_list_sendall(client_l_t *l, struct msghdr *msg) {
-    ssize_t sent = 0;
-    for (unsigned int i = 0; i < MAX_TELEMETRY; i++) {
-
-        if (!client_list_active(l, i)) continue;
-
-        sent = client_list_send(l, i, msg);
-
-        if (sent == -1) {
-            fprintf(stderr, "Could not sent to client %u with error: %s\n", i, strerror(errno));
-            client_list_remove(l, i);
-        } else if (sent == 0) {
-            printf("Client %u disconnected.\n", i);
-            client_list_remove(l, i);
-        }
-    }
-}
-
-/*
- * Thread to continuously accept new connections as long as there's space.
- * @param arg Arguments to the connection accepting thread of type `struct accept_args`.
- * @return The thread's exit code.
- */
-static void *telemetry_accept_thread(void *arg) {
-
-    struct accept_args *args = (struct accept_args *)(arg);
-    int new_client;
-    int err;
-
-    for (;;) {
-
-        /* Listen for one allowed connection. */
-        if (listen(args->master_sock, 1) < 0) {
-            fprintf(stderr, "Could not listen for new clients with error: %s\n", strerror(errno));
-        }
-
-        /* Accept the first incoming connection. */
-        new_client = accept(args->master_sock, NULL, 0);
-        if (new_client < 0) {
-            fprintf(stderr, "Couldn't accept connection with error: %s\n", strerror(errno));
-        }
-
-        /* Add the client to the list. */
-        err = client_list_add(args->list, new_client);
-        if (err) {
-            fprintf(stderr, "Couldn't add new client to the list with error: %s\n", strerror(errno));
-        }
-        printf("New telemetry client connected.\n");
-    }
-
-    thread_return(0);
-}
 
 /*
  * Cleanup function to kill a thread.
@@ -265,20 +104,6 @@ void *telemetry_run(void *arg) {
         thread_return(err);
     }
     pthread_cleanup_push(telemetry_cleanup, &telem);
-
-    /* Create client list */
-    client_l_t list;
-    client_list_init(&list);
-
-    /* Start thread to accept new connections */
-    pthread_t accept_thread;
-    struct accept_args accept_thread_args = {.list = &list, .master_sock = telem.sock};
-    err = pthread_create(&accept_thread, NULL, telemetry_accept_thread, &accept_thread_args);
-    if (err) {
-        fprintf(stderr, "Could not create thread to accept new connections: %s\n", strerror(err));
-        thread_return(err);
-    }
-    pthread_cleanup_push(cancel_wrapper, &accept_thread);
 
     /* Open telemetry file */
     FILE *data = fopen(args->data_file, "r");
@@ -330,13 +155,12 @@ void *telemetry_run(void *arg) {
             .msg_controllen = 0,
             .msg_flags = 0,
         };
-        client_list_sendall(&list, &msg);
+        telemetry_publish(&telem, &msg);
 
         usleep(1000);
     }
 
     thread_return(0); // Normal return
 
-    pthread_cleanup_pop(1);
     pthread_cleanup_pop(1);
 }

--- a/telem_client/src/main.c
+++ b/telem_client/src/main.c
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
 
     int err;
 
-    err = stream_init(&telem_stream, "127.0.0.1", TELEM_PORT);
+    err = stream_init(&telem_stream, "224.0.0.10", TELEM_PORT);
     if (err) {
         fprintf(stderr, "Could not initialize telemetry stream: %s\n", strerror(err));
         exit(EXIT_FAILURE);

--- a/telem_client/src/main.c
+++ b/telem_client/src/main.c
@@ -59,18 +59,6 @@ int main(int argc, char **argv) {
         fprintf(stderr, "Could not initialize telemetry stream: %s\n", strerror(err));
         exit(EXIT_FAILURE);
     }
-
-    printf("Waiting to connect...\n");
-    err = ECONNREFUSED;
-    do {
-        err = stream_connect(&telem_stream);
-    } while (err == ECONNREFUSED);
-
-    if (err) {
-        fprintf(stderr, "Could not connect to telemetry stream: %s\n", strerror(err));
-        exit(EXIT_FAILURE);
-    }
-    printf("Connected!\n");
     signal(SIGINT, handle_int);
 
     /* Get messages forever */

--- a/telem_client/src/stream.c
+++ b/telem_client/src/stream.c
@@ -1,11 +1,14 @@
 #include <arpa/inet.h>
 #include <errno.h>
+#include <netdb.h>
 #include <netinet/in.h>
 #include <stdint.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 #include "stream.h"
+
+#define MULTICAST_ADDR "224.0.0.10"
 
 /*
  * Initialize a stream in preparation for connection.
@@ -14,34 +17,37 @@
 int stream_init(stream_t *stream, const char *ip, uint16_t port) {
 
     /* Create TCP socket */
-    stream->sock = socket(AF_INET, SOCK_STREAM, 0);
+    stream->sock = socket(AF_INET, SOCK_DGRAM, 0);
     if (stream->sock < 0) {
         return errno;
     }
 
     /* Create address for socket */
     stream->addr.sin_family = AF_INET;
+    stream->addr.sin_addr.s_addr = htonl(INADDR_ANY);
     stream->addr.sin_port = htons(port);
 
-    /* Convert IPv4 address to integer */
-    int ret = inet_pton(AF_INET, ip, &stream->addr.sin_addr);
-    if (ret == 0) {
-        return EINVAL;
-    } else if (ret < 0) {
+    /* Register for multicast */
+    struct ip_mreq mreq;
+    mreq.imr_multiaddr.s_addr = inet_addr(MULTICAST_ADDR);
+    mreq.imr_interface.s_addr = htonl(INADDR_ANY);
+
+    /* Register with multicast group */
+    if (setsockopt(stream->sock, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0) {
         return errno;
     }
 
-    return 0;
-}
-
-/*
- * Connect the stream to the telemetry server.
- * TODO: docs
- */
-int stream_connect(stream_t *stream) {
-    if (connect(stream->sock, (struct sockaddr *)&stream->addr, sizeof(stream->addr)) < 0) {
+    /* Re-use port so testing can be done on the same machine. */
+    int reuse = 1;
+    if (setsockopt(stream->sock, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) == -1) {
         return errno;
     }
+
+    /* Bind the socket for use. */
+    if (bind(stream->sock, (struct sockaddr *)&stream->addr, sizeof(stream->addr)) < 0) {
+        return errno;
+    }
+
     return 0;
 }
 
@@ -60,4 +66,7 @@ int stream_disconnect(stream_t *stream) {
  * Receive bytes from the telemetry upstream.
  * TODO: docs
  */
-ssize_t stream_recv(stream_t *stream, void *buf, size_t n) { return recv(stream->sock, buf, n, 0); }
+ssize_t stream_recv(stream_t *stream, void *buf, size_t n) {
+    socklen_t size = sizeof(stream->addr);
+    return recvfrom(stream->sock, buf, n, 0, (struct sockaddr *)&stream->addr, &size);
+}


### PR DESCRIPTION
This PR implements UDP multicasting for telemetry messages. The pad server now publishes telemetry messages to the
agreed upon multicast address so that infinite clients can subscribe to the multicast group. The telemetry client is now
a multicast subscriber, and is allowed to reuse ports so that multiple clients can connect to the same telemetry stream.