### PR TITLE
Add pthread option to pad compilation command

### DIFF
--- a/pad_server/Makefile
+++ b/pad_server/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -Wextra
+CFLAGS = -Wall -Wextra -pthread
 OUT = pad
 
 SRCDIR = $(abspath ./src)


### PR DESCRIPTION
On my computer (WSL 2) compilation fails for the `pad` executable, with notes about undefined references to pthread functions: 

```
make -C /home/angus/hysim/control_client
make[1]: Entering directory '/home/angus/hysim/control_client'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/angus/hysim/control_client'
make -C /home/angus/hysim/pad_server
make[1]: Entering directory '/home/angus/hysim/pad_server'
gcc -Wall -Wextra -lpthread /home/angus/hysim/pad_server/src/state.o /home/angus/hysim/pad_server/src/actuator.o /home/angus/hysim/pad_server/src/main.o /home/angus/hysim/pad_server/src/controller.o /home/angus/hysim/pad_server/src/telemetry.o ../packets/packet.o -o pad
/usr/bin/ld: /home/angus/hysim/pad_server/src/main.o: in function `int_handler':
main.c:(.text+0x52): undefined reference to `pthread_cancel'
/usr/bin/ld: main.c:(.text+0x9e): undefined reference to `pthread_cancel'
/usr/bin/ld: /home/angus/hysim/pad_server/src/main.o: in function `main':
main.c:(.text+0x2a3): undefined reference to `pthread_create'
/usr/bin/ld: main.c:(.text+0x300): undefined reference to `pthread_create'
/usr/bin/ld: main.c:(.text+0x360): undefined reference to `pthread_join'
/usr/bin/ld: main.c:(.text+0x3a5): undefined reference to `pthread_join'
/usr/bin/ld: /home/angus/hysim/pad_server/src/controller.o: in function `controller_run':
controller.c:(.text+0x2e5): undefined reference to `__pthread_register_cancel'
/usr/bin/ld: /home/angus/hysim/pad_server/src/telemetry.o: in function `cancel_wrapper':
telemetry.c:(.text+0x5f9): undefined reference to `pthread_cancel'
/usr/bin/ld: /home/angus/hysim/pad_server/src/telemetry.o: in function `telemetry_run':
telemetry.c:(.text+0x74e): undefined reference to `__pthread_register_cancel'
/usr/bin/ld: telemetry.c:(.text+0x79c): undefined reference to `pthread_create'
/usr/bin/ld: telemetry.c:(.text+0x85e): undefined reference to `__pthread_register_cancel'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:14: pad] Error 1
make[1]: Leaving directory '/home/angus/hysim/pad_server'
make: *** [Makefile:8: pad_server] Error 2
```
Adding the -pthread flag will fix this error. The GCC page that lists this options can be found here: https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html
