### PR TITLE
Remove Docker detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ $ control_client/control
 
 ## Running with Docker
 
-If you have docker installed, you can run simulations within a docker container.
+If you have Docker installed, you can run simulations within a Docker container.
 
 To build the image run `docker build . -t hysim`.
 
-In order to be able to receive data over TCP/UDP sockets, we have to manually expose the port when creating the container. To create a container with the exposed port for telemetry data, run `docker run -p 50002:50002 hysim` 
+In order to be able to receive data over TCP/UDP sockets, we have to manually expose the port when creating the 
+container. To create a container with the exposed port for telemetry data, run `docker run -it -p 50002:50002 hysim` 

--- a/pad_server/src/main.c
+++ b/pad_server/src/main.c
@@ -25,17 +25,6 @@ controller_args_t controller_args = {.port = CONTROL_PORT, .state = &state};
 pthread_t telem_thread;
 telemetry_args_t telemetry_args = {.port = TELEMETRY_PORT, .state = &state, .data_file = NULL};
 
-/*
- * Simple function to check if program is running inside docker container
- */
-int is_running_in_docker() {
-    // Check if the `.dockerenv` file exists
-    if (access("/.dockerenv", F_OK) != -1) {
-        return 1;  // File exists, running inside Docker
-    }
-    return 0;  // File doesn't exist, not running inside Docker
-}
-
 void int_handler(int sig) {
 
     (void)(sig);
@@ -106,10 +95,6 @@ int main(int argc, char **argv) {
             exit(EXIT_FAILURE);
             break;
         }
-    }
-    
-    if (is_running_in_docker()){
-        setvbuf(stdout, NULL, _IONBF, 0);
     }
 
     if (telemetry_args.port == controller_args.port) {


### PR DESCRIPTION
Turns out you can avoid the buffering of stdout by running interactively. This is the preferred approach because:

- It does not require any modification of the logic to detect different platforms (close to production environment)
- Not all software that will run in our Docker containers will perform buffering configuration, so it's good to have an external way to display stdout in a line-buffered mode