### PR TITLE
Control client doesn't reconnect after quit

### DIFF
--- a/pad_server/src/controller.c
+++ b/pad_server/src/controller.c
@@ -167,7 +167,6 @@ void *controller_run(void *arg) {
                 case CNTRL_ACT_ACK:
                 case CNTRL_ARM_ACK:
                     fprintf(stderr, "Unexpectedly received acknowledgement from sender.\n");
-                    thread_return(EXIT_FAILURE);
                     break;
                 case CNTRL_ACT_REQ: {
                     act_req_p req;
@@ -184,7 +183,6 @@ void *controller_run(void *arg) {
                 break;
             default:
                 fprintf(stderr, "Invalid message type: %u\n", hdr.type);
-                thread_return(EXIT_FAILURE);
                 break;
             }
         }

--- a/pad_server/src/controller.c
+++ b/pad_server/src/controller.c
@@ -24,13 +24,6 @@ static int controller_init(controller_t *controller, uint16_t port) {
     controller->sock = socket(AF_INET, SOCK_STREAM, 0);
     if (controller->sock < 0) return errno;
 
-    /* Set SO_REUSEADDR option */
-    int opt = 1;
-    if (setsockopt(controller->sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
-        close(controller->sock);
-        return errno;
-    }
-
     /* Create address */
     controller->addr.sin_family = AF_INET;
     controller->addr.sin_addr.s_addr = INADDR_ANY;
@@ -104,6 +97,9 @@ static ssize_t controller_recv(controller_t *controller, void *buf, size_t n) {
     return recv(controller->client, buf, n, 0);
 }
 
+/* Run the controller logic
+ * TODO: docs
+ */
 void *controller_run(void *arg) {
     controller_args_t *args = (controller_args_t *)(arg);
     controller_t controller;

--- a/pad_server/src/controller.c
+++ b/pad_server/src/controller.c
@@ -110,13 +110,14 @@ static ssize_t controller_recv(controller_t *controller, void *buf, size_t n) {
 void *controller_run(void *arg) {
     controller_args_t *args = (controller_args_t *)(arg);
     controller_t controller;
-    int err;
+    controller.sock = -1;
+    controller.client = -1;
 
     pthread_cleanup_push(controller_cleanup, &controller);
     fprintf(stderr, "Waiting for controller...\n");
 
     for (;;) {
-
+        int err;
         /* Initialize the controller (creates a new socket) */
         err = controller_init(&controller, args->port);
         if (err) {


### PR DESCRIPTION
Closes #19

Modified controller_run so that the initialization and connection happens on controller disconnect.

The program was tested by running both pad_server and control_client and repeatedly restarting the latter.

#### What does not work yet:
- client re-connection if the pad_server restarts