### PR TITLE
Added control_client request acknowledgement and changed it's packet sending method to sendmsg

### DIFF
--- a/control_client/src/main.c
+++ b/control_client/src/main.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "../../packets/packet.h"
@@ -66,6 +67,7 @@ static command_t commands[] = {
 
 uint16_t port = 50001; /* Default port */
 pad_t pad;
+arm_t arm;
 
 void handle_term(int sig) {
     (void)sig;
@@ -128,25 +130,81 @@ int main(int argc, char **argv) {
 
             if (commands[i].key == key) {
                 header_p hdr = {.type = TYPE_CNTRL, .subtype = commands[i].subtype}; // create header
+                ssize_t iovlen = 2;
+                struct iovec iov[iovlen];
+                iov[0].iov_base = &hdr;
+                iov[0].iov_len = sizeof(hdr);
 
                 // check what type of command it is
                 switch (commands[i].subtype) {
                 case CNTRL_ACT_REQ: {
-                    switch_t *actuator = commands[i].priv;                                  // get the actuator data
-                    actuator->state = !actuator->state;                                     // flip the state
-                    act_req_p act_req = {.id = actuator->act_id, .state = actuator->state}; // Create message
+                    switch_t *actuator = commands[i].priv;                                   // get the actuator data
+                    act_req_p act_req = {.id = actuator->act_id, .state = !actuator->state}; // Create message
 
-                    pad_send(&pad, &hdr, sizeof(hdr));
-                    pad_send(&pad, &act_req, sizeof(act_req));
-                    break;
-                }
+                    iov[1].iov_base = &act_req;
+                    iov[1].iov_len = sizeof(act_req);
+                    pad_send(&pad, iov, iovlen);
+
+                    act_ack_p act_ack;
+                    err = pad_recv(&pad, &act_ack, sizeof(act_ack));
+                    if (err <= 0) {
+                        fprintf(stderr, "Server did not acknowledge actuator request with id %d\n", actuator->act_id);
+                        break;
+                    }
+
+                    switch (act_ack.status) {
+                    case ACT_OK:
+                        fprintf(stderr,
+                                "The pad control system has put the actuator with id %d in the requested state\n",
+                                act_ack.id);
+                        actuator->state = !actuator->state; // flipping the state of the actuator
+                        break;
+                    case ACT_DENIED:
+                        fprintf(stderr, "The current level is too low to operate the actuator with id %d\n",
+                                act_ack.id);
+                        break;
+                    case ACT_DNE:
+                        fprintf(stderr, "Actuator id %d is not associated with any actuator\n", act_ack.id);
+                        break;
+                    case ACT_INV:
+                        fprintf(stderr, "Invalid state was requested for actuator with id %d\n", act_ack.id);
+                        break;
+                    }
+                } break;
+
                 case CNTRL_ARM_REQ: {
                     uint8_t *level = commands[i].priv;             // get arming level data
                     arm_req_p arm_req = {.level = (uint8_t)level}; // create message
-                    pad_send(&pad, &hdr, sizeof(hdr));
-                    pad_send(&pad, &arm_req, sizeof(arm_req));
-                    break;
-                }
+
+                    iov[1].iov_base = &arm_req;
+                    iov[1].iov_len = sizeof(arm_req);
+                    pad_send(&pad, iov, iovlen);
+
+                    arm_ack_p arm_ack;
+                    err = pad_recv(&pad, &arm_ack, sizeof(arm_ack));
+                    if (err <= 0) {
+                        fprintf(stderr, "Server did not acknowledge arming request with level %d\n", arm_req.level);
+                        break;
+                    }
+
+                    switch (arm_ack.status) {
+                    case ARM_OK:
+                        fprintf(stderr, "Arming request with level %d was processed succesfully\n", arm_req.level);
+                        arm.level = arm_req.level; // saving the arming level
+                        break;
+                    case ARM_DENIED:
+                        fprintf(stderr,
+                                "The arming request with level %d could not be completed because the current arming "
+                                "level is not high enough for that progression, or the progression must be caused via "
+                                "an actuator command\n",
+                                arm_req.level);
+                        break;
+                    case ARM_INV:
+                        fprintf(stderr, "Invalid arming level %d was specified\n", arm_req.level);
+                        break;
+                    }
+                } break;
+
                 case CNTRL_ACT_ACK:
                 case CNTRL_ARM_ACK:
                     break;

--- a/control_client/src/pad.c
+++ b/control_client/src/pad.c
@@ -3,9 +3,11 @@
 #include <netinet/in.h>
 #include <stdint.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "pad.h"
+#define RCVTIMEO_SEC 3;
 
 /*
  * Initialize a pad structure.
@@ -21,6 +23,11 @@ int pad_init(pad_t *pad, const char *ip, uint16_t port) {
     if (pad->sock < 0) {
         return errno;
     }
+
+    struct timeval tv;
+    tv.tv_sec = RCVTIMEO_SEC;
+    tv.tv_usec = 0;
+    setsockopt(pad->sock, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof tv);
 
     /* Create address */
     pad->addr.sin_family = AF_INET;
@@ -71,7 +78,12 @@ int pad_connect_forever(pad_t *pad) {
  * @param n The number of bytes in `buf` to be sent.
  * @return The number of bytes that were sent, or -1 on failure (errno indicates the error).
  */
-ssize_t pad_send(pad_t *pad, const void *buf, size_t n) { return send(pad->sock, buf, n, 0); }
+ssize_t pad_send(pad_t *pad, struct iovec *iov, ssize_t iovlen) {
+    struct msghdr msg = {0};
+    msg.msg_iov = iov;
+    msg.msg_iovlen = iovlen;
+    return sendmsg(pad->sock, &msg, 0);
+}
 
 /*
  * Close the connection to the pad server.
@@ -84,3 +96,12 @@ int pad_disconnect(pad_t *pad) {
     }
     return 0;
 }
+
+/*
+ * Receive a message from the pad server.
+ * @param pad The pad server to send a message to.
+ * @param buf The destination buffer.
+ * @param n The size of the destination buffer.
+ * @return The number of bytes that were received, or -1 on failure (errno indicates the error).
+ */
+ssize_t pad_recv(pad_t *pad, void *buf, ssize_t n) { return recv(pad->sock, buf, n, 0); }

--- a/control_client/src/pad.h
+++ b/control_client/src/pad.h
@@ -15,6 +15,7 @@ int pad_init(pad_t *pad, const char *ip, uint16_t port);
 int pad_connect(pad_t *pad);
 int pad_connect_forever(pad_t *pad);
 int pad_disconnect(pad_t *pad);
-ssize_t pad_send(pad_t *pad, const void *buf, size_t n);
+ssize_t pad_send(pad_t *pad, struct iovec *iov, ssize_t iovlen);
+ssize_t pad_recv(pad_t *pad, void *buf, ssize_t n);
 
 #endif // _PAD_H_


### PR DESCRIPTION
### Changes
 - pad_client now sends the packet all at once with sendmsg instead of send
 - pad_server receives the request and answers with an acknowledgement
 - if the pad_server doesn't send the acknowledgement by  `#define RCVTIMEO_SEC 3;` seconds (need feedback on this) the pad_client marks the request as failed

The code was properly tested, it integrates the hybric-comm specs and works as expected

### What is missing
- There is no acknowledgement with error code for incorrect or malformed headers, need comment on this part

I'm not sure if I have a different .clang-formatter somewhere or someone else is not using the one provided by the repo but I keep having formatting diffs in my commits.
 
