### PR TITLE
Handled reconnection of control_client

### DIFF
--- a/control_client/src/main.c
+++ b/control_client/src/main.c
@@ -1,3 +1,4 @@
+#include "errno.h"
 #include <arpa/inet.h>
 #include <signal.h>
 #include <stdbool.h>
@@ -98,20 +99,18 @@ int main(int argc, char **argv) {
         }
     }
 
+    int err;
+
     signal(SIGINT, handle_term);
+
     char key;
     for (;;) {
-        int err;
-        bool pad_connected = true;
-
         fprintf(stderr, "Waiting for pad...\n");
         err = pad_init(&pad, "127.0.0.1", port);
         if (err) {
             fprintf(stderr, "Could not initialize pad server with error: %s\n", strerror(err));
             exit(EXIT_FAILURE);
         }
-
-        /* Handle disconnects */
 
         err = pad_connect_forever(&pad);
         if (err) {
@@ -152,11 +151,13 @@ int main(int argc, char **argv) {
 
                         act_ack_p act_ack;
                         err = pad_recv(&pad, &act_ack, sizeof(act_ack));
-                        if (err <= 0) {
-                            fprintf(stderr, "Server did not acknowledge actuator request with id %d, reconnecting...\n",
+                        if (err == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                            fprintf(stderr, "Server did not acknowledge actuator request with id %d\n",
                                     actuator->act_id);
+                            break;
+                        } else if (err == 0 || (err == -1 && (errno == ECONNREFUSED || errno == ECONNRESET))) {
+                            fprintf(stderr, "Server unreachable... reconnecting\n");
                             pad_disconnect(&pad);
-                            pad_connected = false;
                             break;
                         }
 
@@ -190,12 +191,12 @@ int main(int argc, char **argv) {
 
                         arm_ack_p arm_ack;
                         err = pad_recv(&pad, &arm_ack, sizeof(arm_ack));
-                        if (err <= 0) {
-                            fprintf(stderr,
-                                    "Server did not acknowledge arming request with level %d, reconnecting...\n",
-                                    arm_req.level);
+                        if (err == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                            fprintf(stderr, "Server did not acknowledge arming request with level %d\n", arm_req.level);
+                            break;
+                        } else if (err == 0 || (err == -1 && (errno == ECONNREFUSED || errno == ECONNRESET))) {
+                            fprintf(stderr, "Server unreachable... reconnecting\n");
                             pad_disconnect(&pad);
-                            pad_connected = false;
                             break;
                         }
 
@@ -229,8 +230,8 @@ int main(int argc, char **argv) {
                     fprintf(stderr, "Invalid key: %c", key);
                 }
             }
-            putchar('\n');
-            if (pad_connected == false) {
+
+            if (pad.sock == -1) {
                 break;
             }
         }

--- a/control_client/src/main.c
+++ b/control_client/src/main.c
@@ -1,5 +1,6 @@
 #include <arpa/inet.h>
 #include <signal.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -76,6 +77,7 @@ void handle_term(int sig) {
 }
 
 int main(int argc, char **argv) {
+    pad.sock = -1;
 
     /* Parse command line options. */
 
@@ -96,127 +98,142 @@ int main(int argc, char **argv) {
         }
     }
 
-    int err;
-    err = pad_init(&pad, "127.0.0.1", port);
-    if (err) {
-        fprintf(stderr, "Could not initialize pad server with error: %s\n", strerror(err));
-        exit(EXIT_FAILURE);
-    }
-
-    /* Handle disconnects */
     signal(SIGINT, handle_term);
-
-    err = pad_connect_forever(&pad);
-    if (err) {
-        fprintf(stderr, "Could not connect to pad server with error: %s\n", strerror(err));
-        exit(EXIT_FAILURE);
-    }
-
-    printf("Connection established!\n");
-
-    /* Send messages in a loop */
-
     char key;
     for (;;) {
+        int err;
+        bool pad_connected = true;
 
-        printf("Press key and hit enter: ");
-        key = getc(stdin);
-        if (key != '\n') {
-            while (getc(stdin) != '\n')
-                ;
+        fprintf(stderr, "Waiting for pad...\n");
+        err = pad_init(&pad, "127.0.0.1", port);
+        if (err) {
+            fprintf(stderr, "Could not initialize pad server with error: %s\n", strerror(err));
+            exit(EXIT_FAILURE);
         }
 
-        for (unsigned int i = 0; i < sizeof(commands) / sizeof(commands[0]); i++) {
+        /* Handle disconnects */
 
-            if (commands[i].key == key) {
-                header_p hdr = {.type = TYPE_CNTRL, .subtype = commands[i].subtype}; // create header
-                ssize_t iovlen = 2;
-                struct iovec iov[iovlen];
-                iov[0].iov_base = &hdr;
-                iov[0].iov_len = sizeof(hdr);
+        err = pad_connect_forever(&pad);
+        if (err) {
+            fprintf(stderr, "Could not connect to pad server with error: %s\n", strerror(err));
+            exit(EXIT_FAILURE);
+        }
 
-                // check what type of command it is
-                switch (commands[i].subtype) {
-                case CNTRL_ACT_REQ: {
-                    switch_t *actuator = commands[i].priv;                                   // get the actuator data
-                    act_req_p act_req = {.id = actuator->act_id, .state = !actuator->state}; // Create message
+        printf("Connection established!\n");
 
-                    iov[1].iov_base = &act_req;
-                    iov[1].iov_len = sizeof(act_req);
-                    pad_send(&pad, iov, iovlen);
+        /* Send messages in a loop */
+        for (;;) {
 
-                    act_ack_p act_ack;
-                    err = pad_recv(&pad, &act_ack, sizeof(act_ack));
-                    if (err <= 0) {
-                        fprintf(stderr, "Server did not acknowledge actuator request with id %d\n", actuator->act_id);
-                        break;
-                    }
+            printf("Press key and hit enter: ");
+            key = getc(stdin);
+            if (key != '\n') {
+                while (getc(stdin) != '\n')
+                    ;
+            }
 
-                    switch (act_ack.status) {
-                    case ACT_OK:
-                        fprintf(stderr,
-                                "The pad control system has put the actuator with id %d in the requested state\n",
-                                act_ack.id);
-                        actuator->state = !actuator->state; // flipping the state of the actuator
-                        break;
-                    case ACT_DENIED:
-                        fprintf(stderr, "The current level is too low to operate the actuator with id %d\n",
-                                act_ack.id);
-                        break;
-                    case ACT_DNE:
-                        fprintf(stderr, "Actuator id %d is not associated with any actuator\n", act_ack.id);
-                        break;
-                    case ACT_INV:
-                        fprintf(stderr, "Invalid state was requested for actuator with id %d\n", act_ack.id);
-                        break;
-                    }
-                } break;
+            for (unsigned int i = 0; i < sizeof(commands) / sizeof(commands[0]); i++) {
 
-                case CNTRL_ARM_REQ: {
-                    uint8_t *level = commands[i].priv;             // get arming level data
-                    arm_req_p arm_req = {.level = (uint8_t)level}; // create message
+                if (commands[i].key == key) {
+                    header_p hdr = {.type = TYPE_CNTRL, .subtype = commands[i].subtype}; // create header
+                    ssize_t iovlen = 2;
+                    struct iovec iov[iovlen];
+                    iov[0].iov_base = &hdr;
+                    iov[0].iov_len = sizeof(hdr);
 
-                    iov[1].iov_base = &arm_req;
-                    iov[1].iov_len = sizeof(arm_req);
-                    pad_send(&pad, iov, iovlen);
+                    // check what type of command it is
+                    switch (commands[i].subtype) {
+                    case CNTRL_ACT_REQ: {
+                        switch_t *actuator = commands[i].priv; // get the actuator data
+                        act_req_p act_req = {.id = actuator->act_id, .state = !actuator->state}; // Create message
 
-                    arm_ack_p arm_ack;
-                    err = pad_recv(&pad, &arm_ack, sizeof(arm_ack));
-                    if (err <= 0) {
-                        fprintf(stderr, "Server did not acknowledge arming request with level %d\n", arm_req.level);
-                        break;
-                    }
+                        iov[1].iov_base = &act_req;
+                        iov[1].iov_len = sizeof(act_req);
+                        pad_send(&pad, iov, iovlen);
 
-                    switch (arm_ack.status) {
-                    case ARM_OK:
-                        fprintf(stderr, "Arming request with level %d was processed succesfully\n", arm_req.level);
-                        arm.level = arm_req.level; // saving the arming level
-                        break;
-                    case ARM_DENIED:
-                        fprintf(stderr,
+                        act_ack_p act_ack;
+                        err = pad_recv(&pad, &act_ack, sizeof(act_ack));
+                        if (err <= 0) {
+                            fprintf(stderr, "Server did not acknowledge actuator request with id %d, reconnecting...\n",
+                                    actuator->act_id);
+                            pad_disconnect(&pad);
+                            pad_connected = false;
+                            break;
+                        }
+
+                        switch (act_ack.status) {
+                        case ACT_OK:
+                            fprintf(stderr,
+                                    "The pad control system has put the actuator with id %d in the requested state\n",
+                                    act_ack.id);
+                            actuator->state = !actuator->state; // flipping the state of the actuator
+                            break;
+                        case ACT_DENIED:
+                            fprintf(stderr, "The current level is too low to operate the actuator with id %d\n",
+                                    act_ack.id);
+                            break;
+                        case ACT_DNE:
+                            fprintf(stderr, "Actuator id %d is not associated with any actuator\n", act_ack.id);
+                            break;
+                        case ACT_INV:
+                            fprintf(stderr, "Invalid state was requested for actuator with id %d\n", act_ack.id);
+                            break;
+                        }
+                    } break;
+
+                    case CNTRL_ARM_REQ: {
+                        uint8_t *level = commands[i].priv;             // get arming level data
+                        arm_req_p arm_req = {.level = (uint8_t)level}; // create message
+
+                        iov[1].iov_base = &arm_req;
+                        iov[1].iov_len = sizeof(arm_req);
+                        pad_send(&pad, iov, iovlen);
+
+                        arm_ack_p arm_ack;
+                        err = pad_recv(&pad, &arm_ack, sizeof(arm_ack));
+                        if (err <= 0) {
+                            fprintf(stderr,
+                                    "Server did not acknowledge arming request with level %d, reconnecting...\n",
+                                    arm_req.level);
+                            pad_disconnect(&pad);
+                            pad_connected = false;
+                            break;
+                        }
+
+                        switch (arm_ack.status) {
+                        case ARM_OK:
+                            fprintf(stderr, "Arming request with level %d was processed succesfully\n", arm_req.level);
+                            arm.level = arm_req.level; // saving the arming level
+                            break;
+                        case ARM_DENIED:
+                            fprintf(
+                                stderr,
                                 "The arming request with level %d could not be completed because the current arming "
                                 "level is not high enough for that progression, or the progression must be caused via "
                                 "an actuator command\n",
                                 arm_req.level);
-                        break;
-                    case ARM_INV:
-                        fprintf(stderr, "Invalid arming level %d was specified\n", arm_req.level);
+                            break;
+                        case ARM_INV:
+                            fprintf(stderr, "Invalid arming level %d was specified\n", arm_req.level);
+                            break;
+                        }
+                    } break;
+
+                    case CNTRL_ACT_ACK:
+                    case CNTRL_ARM_ACK:
                         break;
                     }
-                } break;
-
-                case CNTRL_ACT_ACK:
-                case CNTRL_ARM_ACK:
                     break;
                 }
+
+                if (i == (sizeof(commands) / sizeof(commands[0]) - 1)) {
+                    fprintf(stderr, "Invalid key: %c", key);
+                }
+            }
+            putchar('\n');
+            if (pad_connected == false) {
                 break;
             }
-
-            if (i == (sizeof(commands) / sizeof(commands[0]) - 1)) {
-                fprintf(stderr, "Invalid key: %c", key);
-            }
         }
-        putchar('\n');
     }
 
     pad_disconnect(&pad);

--- a/control_client/src/pad.c
+++ b/control_client/src/pad.c
@@ -95,6 +95,7 @@ int pad_disconnect(pad_t *pad) {
         if (close(pad->sock) < 0) {
             return errno;
         }
+        pad->sock = -1;
     }
     return 0;
 }

--- a/control_client/src/pad.c
+++ b/control_client/src/pad.c
@@ -91,8 +91,10 @@ ssize_t pad_send(pad_t *pad, struct iovec *iov, ssize_t iovlen) {
  * @return 0 on success, the error that occurred on failure.
  */
 int pad_disconnect(pad_t *pad) {
-    if (close(pad->sock) < 0) {
-        return errno;
+    if (pad->sock >= 0) {
+        if (close(pad->sock) < 0) {
+            return errno;
+        }
     }
     return 0;
 }

--- a/pad_server/src/controller.c
+++ b/pad_server/src/controller.c
@@ -37,16 +37,6 @@ static int controller_init(controller_t *controller, uint16_t port) {
     /* Make sure client socket fd is marked as invalid until it gets a connection */
     controller->client = -1;
 
-    return 0;
-}
-
-/*
- * Bind to the controller client.
- * @param controller The controller to use for the connection.
- * @return 0 for success, or the error that occurred.
- */
-static int controller_bind(controller_t *controller) {
-    /* Bind the controller socket */
     if (bind(controller->sock, (struct sockaddr *)&controller->addr, sizeof(controller->addr)) < 0) {
         return errno;
     }
@@ -85,6 +75,7 @@ static int controller_disconnect(controller_t *controller) {
     // only close the connection if it is valid
     if (controller->client >= 0) {
         if (close(controller->client) < 0) {
+            fprintf(stderr, "REEEE");
             return errno;
         }
         controller->client = -1;
@@ -141,15 +132,7 @@ void *controller_run(void *arg) {
         continue;
     }
 
-    err = controller_bind(&controller);
-    if (err) {
-        fprintf(stderr, "Could not bind controller connection with error: %s\n", strerror(err));
-        controller_disconnect(&controller);
-        continue;
-    }
-
     for (;;) {
-        int err;
         /* Initialize the controller (creates a new socket) */
         err = controller_accept(&controller);
         if (err) {

--- a/pad_server/src/controller.c
+++ b/pad_server/src/controller.c
@@ -129,7 +129,7 @@ void *controller_run(void *arg) {
     err = controller_init(&controller, args->port);
     if (err) {
         fprintf(stderr, "Could not initialize controller with error: %s\n", strerror(err));
-        continue;
+        exit(EXIT_FAILURE);
     }
 
     for (;;) {


### PR DESCRIPTION
- Fixed my own bug where pad_server would close both the listening socket and the client socket. The `controller_accept` function got split into `controller_accept` and a `controller_bind` .`controller_disconnect` now only closes the client socket.
- Added disconnection workflow on control_client in case the server doesn't answer by `RCVTIMEO_SEC` seconds. I'm skeptical about the additional for loop I added, as now we have 3 nested loops. Used the same disconnection logic in the pad_server, where the socket is disconnected only if the socket is <= 0.