### PR TITLE
Change multicast address

### DIFF
--- a/pad_server/src/telemetry.c
+++ b/pad_server/src/telemetry.c
@@ -13,7 +13,7 @@
 
 #include "telemetry.h"
 
-#define MULTICAST_ADDR "224.0.0.10"
+#define MULTICAST_ADDR "239.100.110.210"
 
 /* Helper function for returning an error code from a thread */
 #define thread_return(e) pthread_exit((void *)(unsigned long)((e)))

--- a/telem_client/src/main.c
+++ b/telem_client/src/main.c
@@ -12,6 +12,7 @@
 #include "stream.h"
 
 #define TELEM_PORT 50002
+#define MULTICAST_ADDR "239.100.110.210" 
 
 stream_t telem_stream;
 
@@ -54,7 +55,7 @@ int main(int argc, char **argv) {
 
     int err;
 
-    err = stream_init(&telem_stream, "224.0.0.10", TELEM_PORT);
+    err = stream_init(&telem_stream, MULTICAST_ADDR, TELEM_PORT);
     if (err) {
         fprintf(stderr, "Could not initialize telemetry stream: %s\n", strerror(err));
         exit(EXIT_FAILURE);

--- a/telem_client/src/main.c
+++ b/telem_client/src/main.c
@@ -12,7 +12,7 @@
 #include "stream.h"
 
 #define TELEM_PORT 50002
-#define MULTICAST_ADDR "239.100.110.210" 
+#define MULTICAST_ADDR "239.100.110.210"
 
 stream_t telem_stream;
 

--- a/telem_client/src/stream.c
+++ b/telem_client/src/stream.c
@@ -8,8 +8,6 @@
 
 #include "stream.h"
 
-#define MULTICAST_ADDR "224.0.0.10"
-
 /*
  * Initialize a stream in preparation for connection.
  * TODO: docs
@@ -29,7 +27,7 @@ int stream_init(stream_t *stream, const char *ip, uint16_t port) {
 
     /* Register for multicast */
     struct ip_mreq mreq;
-    mreq.imr_multiaddr.s_addr = inet_addr(MULTICAST_ADDR);
+    mreq.imr_multiaddr.s_addr = inet_addr(ip);
     mreq.imr_interface.s_addr = htonl(INADDR_ANY);
 
     /* Register with multicast group */


### PR DESCRIPTION
This PR changes the multicast address to one that is not reserved as per [this](https://www.iana.org/assignments/multicast-addresses/multicast-addresses.xhtml).

The actual address holds no significance other than the fact that the numbers after 239 sum up to 420.