### PR TITLE
Multicast address as cmd arg

### DIFF
--- a/pad_server/src/helptext/helptext.h
+++ b/pad_server/src/helptext/helptext.h
@@ -4,6 +4,10 @@
     "e containing sensor data telemetry to transmit. If not\n                spec"                                     \
     "ified, no sensor data telemetry will be sent.\n    -t port     The port numb"                                     \
     "er to use for the telemetry connection. If not\n                specified, p"                                     \
-    "ort 50002 is used.\n    -c port     The port number to use for the controlle"                                     \
+    "ort 50002 is used.\n    -a addr     The multicast address for the telemetry connection. If not\n                " \
+    "specified, "                                                                                                      \
+    "address "                                                                                                         \
+    "224.0.0.10 is used.\n"                                                                                            \
+    "    -c port     The port number to use for the controlle"                                                         \
     "r connection. If not\n                specified, port 50001 is used.\n\nEXAM"                                     \
     "PLES:\n    pad -t ../thecoldhasflown.csv\n"

--- a/pad_server/src/helptext/helptext.txt
+++ b/pad_server/src/helptext/helptext.txt
@@ -12,6 +12,8 @@ OPTIONS:
                 specified, no sensor data telemetry will be sent.
     -t port     The port number to use for the telemetry connection. If not
                 specified, port 50002 is used.
+    -a addr     The multicast address for the telemetry connection. If not
+                specified, address 224.0.0.10 is used.
     -c port     The port number to use for the controller connection. If not
                 specified, port 50001 is used.
 

--- a/pad_server/src/main.c
+++ b/pad_server/src/main.c
@@ -1,3 +1,4 @@
+#include <arpa/inet.h>
 #include <getopt.h>
 #include <netinet/in.h>
 #include <pthread.h>
@@ -16,6 +17,7 @@
 
 #define TELEMETRY_PORT 50002
 #define CONTROL_PORT 50001
+#define MULTICAST_ADDR "224.0.0.10"
 
 padstate_t state;
 
@@ -23,7 +25,7 @@ pthread_t controller_thread;
 controller_args_t controller_args = {.port = CONTROL_PORT, .state = &state};
 
 pthread_t telem_thread;
-telemetry_args_t telemetry_args = {.port = TELEMETRY_PORT, .state = &state, .data_file = NULL};
+telemetry_args_t telemetry_args = {.port = TELEMETRY_PORT, .state = &state, .data_file = NULL, .addr = MULTICAST_ADDR};
 
 void int_handler(int sig) {
 
@@ -78,7 +80,7 @@ int main(int argc, char **argv) {
     /* Parse command line options. */
 
     int c;
-    while ((c = getopt(argc, argv, ":ht:c:f:")) != -1) {
+    while ((c = getopt(argc, argv, ":ht:c:f:a:")) != -1) {
         switch (c) {
         case 'h':
             puts(HELP_TEXT);
@@ -92,6 +94,14 @@ int main(int argc, char **argv) {
             break;
         case 'f':
             telemetry_args.data_file = optarg;
+            break;
+        case 'a':
+            telemetry_args.addr = optarg;
+            struct in_addr temp_addr;
+            if (inet_pton(AF_INET, telemetry_args.addr, &temp_addr) != 1) {
+                fprintf(stderr, "Invalid telemetry multicast address %s\n", telemetry_args.addr);
+                exit(EXIT_FAILURE);
+            }
             break;
         case '?':
             fprintf(stderr, "Unknown option -%c\n", optopt);

--- a/pad_server/src/telemetry.c
+++ b/pad_server/src/telemetry.c
@@ -13,8 +13,6 @@
 
 #include "telemetry.h"
 
-#define MULTICAST_ADDR "239.100.110.210"
-
 /* Helper function for returning an error code from a thread */
 #define thread_return(e) pthread_exit((void *)(unsigned long)((e)))
 
@@ -30,7 +28,7 @@ typedef struct {
  * @param port The port number to use to accept connections.
  * @return 0 for success, error code on failure.
  */
-static int telemetry_init(telemetry_sock_t *sock, uint16_t port) {
+static int telemetry_init(telemetry_sock_t *sock, uint16_t port, char *addr) {
 
     /* Initialize the socket connection. */
     sock->sock = socket(AF_INET, SOCK_DGRAM, 0);
@@ -38,7 +36,7 @@ static int telemetry_init(telemetry_sock_t *sock, uint16_t port) {
 
     /* Create address */
     sock->addr.sin_family = AF_INET;
-    sock->addr.sin_addr.s_addr = inet_addr(MULTICAST_ADDR);
+    sock->addr.sin_addr.s_addr = inet_addr(addr);
     sock->addr.sin_port = htons(port);
 
     return 0;
@@ -147,7 +145,7 @@ static void random_data(telemetry_args_t *args) {
     /*Start telemetry socket */
     telemetry_sock_t telem;
     int err;
-    err = telemetry_init(&telem, args->port);
+    err = telemetry_init(&telem, args->port, args->addr);
     if (err) {
         fprintf(stderr, "Could not start telemetry socket: %s\n", strerror(err));
         thread_return(err);
@@ -201,7 +199,7 @@ void *telemetry_run(void *arg) {
 
     /* Start telemetry socket */
     telemetry_sock_t telem;
-    err = telemetry_init(&telem, args->port);
+    err = telemetry_init(&telem, args->port, args->addr);
     if (err) {
         fprintf(stderr, "Could not start telemetry socket: %s\n", strerror(err));
         thread_return(err);

--- a/pad_server/src/telemetry.h
+++ b/pad_server/src/telemetry.h
@@ -11,6 +11,7 @@
 typedef struct {
     padstate_t *state;
     uint16_t port;
+    char *addr;
     char *data_file;
 } telemetry_args_t;
 

--- a/telem_client/src/helptext.h
+++ b/telem_client/src/helptext.h
@@ -1,4 +1,5 @@
 #define HELP_TEXT                                                                                                      \
     "telem_client 0.0.0\n(c) CU InSpace 2024\n\nDESCRIPTION:\n    Acts a client c"                                     \
-    "onsuming telemetry data from the pad server.\n\nUSAGE:\n    telem_client\n\n"                                     \
-    "EXAMPLES:\n    telem_client\n"
+    "onsuming telemetry data from the pad server.\n\nUSAGE:\n    telem_client [options]\n\nOPTIONS:\n"                 \
+    "   -a addr The multicast address to listen on. If not specified, address 224.0.0.10 is used. \n\n"                \
+    "EXAMPLES:\n    telem_client -a 224.0.0.10\n"

--- a/telem_client/src/helptext.txt
+++ b/telem_client/src/helptext.txt
@@ -5,7 +5,10 @@ DESCRIPTION:
     Acts a client consuming telemetry data from the pad server.
 
 USAGE:
-    telem_client
+    telem_client [options]
+
+OPTIONS:
+   -a addr The multicast address to listen on.If not specified, address 224.0.0.10 is used.
 
 EXAMPLES:
-    telem_client
+    telem_client -a 224.0.0.10

--- a/telem_client/src/main.c
+++ b/telem_client/src/main.c
@@ -1,3 +1,4 @@
+#include <arpa/inet.h>
 #include <errno.h>
 #include <getopt.h>
 #include <signal.h>
@@ -36,16 +37,26 @@ void handle_int(int sig) {
 }
 
 int main(int argc, char **argv) {
+    char *multicast_addr = "224.0.0.10";
 
     /* Parse command line options. */
 
     int c;
-    while ((c = getopt(argc, argv, ":h")) != -1) {
+    while ((c = getopt(argc, argv, ":ha:")) != -1) {
         switch (c) {
         case 'h':
             puts(HELP_TEXT);
             exit(EXIT_SUCCESS);
             break;
+        case 'a':
+            multicast_addr = optarg;
+            struct in_addr temp_addr;
+            if (inet_pton(AF_INET, multicast_addr, &temp_addr) != 1) {
+                fprintf(stderr, "Invalid multicast address %s\n", multicast_addr);
+                exit(EXIT_FAILURE);
+            }
+            break;
+
         case '?':
             fprintf(stderr, "Unknown option -%c\n", optopt);
             exit(EXIT_FAILURE);
@@ -55,7 +66,7 @@ int main(int argc, char **argv) {
 
     int err;
 
-    err = stream_init(&telem_stream, MULTICAST_ADDR, TELEM_PORT);
+    err = stream_init(&telem_stream, multicast_addr, TELEM_PORT);
     if (err) {
         fprintf(stderr, "Could not initialize telemetry stream: %s\n", strerror(err));
         exit(EXIT_FAILURE);
@@ -67,7 +78,6 @@ int main(int argc, char **argv) {
     header_p hdr;
     ssize_t b_read;
     for (;;) {
-
         b_read = stream_recv(&telem_stream, &hdr, sizeof(hdr));
 
         if (b_read == 0) {


### PR DESCRIPTION
Closes #33, closes #34

- Added the address command line option, as well as checking whether or not it is valid with `inet_pton`
- Updated help text