### PR TITLE
Fix signedness of pressure and temperature types

### DIFF
--- a/packets/packet.c
+++ b/packets/packet.c
@@ -44,7 +44,7 @@ void packet_temp_init(temp_p *p, uint8_t id, uint32_t time, int32_t temperature)
     p->temperature = temperature;
 }
 
-void packet_pressure_init(pressure_p *p, uint8_t id, uint32_t time, uint32_t pressure) {
+void packet_pressure_init(pressure_p *p, uint8_t id, uint32_t time, int32_t pressure) {
     p->id = id;
     p->time = time;
     p->pressure = pressure;

--- a/packets/packet.h
+++ b/packets/packet.h
@@ -98,7 +98,7 @@ typedef struct {
 /* Pressure measurement message */
 typedef struct {
     uint32_t time;     /* Time stamp in milliseconds since power on. */
-    uint32_t pressure; /* Pressure in thousandths of a PSI. */
+    int32_t pressure; /* Pressure in thousandths of a PSI. */
     uint8_t id;        /* The ID of the sensor which reported the measurement. */
 } PACKED pressure_p;
 
@@ -148,7 +148,7 @@ void packet_arm_ack_init(arm_ack_p *ack, arm_ack_status_e status);
 /* TELEMETRY MESSAGES */
 
 void packet_temp_init(temp_p *p, uint8_t id, uint32_t time, int32_t temperature);
-void packet_pressure_init(pressure_p *p, uint8_t id, uint32_t time, uint32_t pressure);
+void packet_pressure_init(pressure_p *p, uint8_t id, uint32_t time, int32_t pressure);
 void packet_mass_init(mass_p *p, uint8_t id, uint32_t time, uint32_t mass);
 void packet_arm_state_init(arm_state_p *p, uint32_t time, arm_lvl_e state);
 void packet_act_state_init(act_state_p *p, uint8_t id, uint32_t time, bool state);

--- a/packets/packet.h
+++ b/packets/packet.h
@@ -97,9 +97,9 @@ typedef struct {
 
 /* Pressure measurement message */
 typedef struct {
-    uint32_t time;     /* Time stamp in milliseconds since power on. */
+    uint32_t time;    /* Time stamp in milliseconds since power on. */
     int32_t pressure; /* Pressure in thousandths of a PSI. */
-    uint8_t id;        /* The ID of the sensor which reported the measurement. */
+    uint8_t id;       /* The ID of the sensor which reported the measurement. */
 } PACKED pressure_p;
 
 /* Mass measurement message */

--- a/pad_server/src/telemetry.c
+++ b/pad_server/src/telemetry.c
@@ -98,7 +98,7 @@ static void telemetry_publish_data(telemetry_sock_t *sock, telem_subtype_e type,
                                    void *data) {
     header_p hdr = {.type = TYPE_TELEM, .subtype = type};
     pressure_p pressureBody = {.id = id, .time = time, .pressure = deref(int32_t, data)};
-    temp_p temperatureBody = {.id = id, .time = time, .temperature = deref(uint32_t, data)};
+    temp_p temperatureBody = {.id = id, .time = time, .temperature = deref(int32_t, data)};
     mass_p massBody = {.id = id, .time = time, .mass = deref(uint32_t, data)};
 
     struct iovec pkt[2] = {


### PR DESCRIPTION
Related to https://github.com/CarletonURocketry/hybrid-comm-format/pull/7#pullrequestreview-2521042925

Fixes the signedness of pressure and temp types for telemetry.