### PR TITLE
Added support for mass sensor telemetry

### DIFF
--- a/packets/packet.h
+++ b/packets/packet.h
@@ -105,7 +105,7 @@ typedef struct {
 /* Mass measurement message */
 typedef struct {
     uint32_t time; /* Time stamp in milliseconds since power on. */
-    uint32_t mass; /* Mass in grams. */
+    int32_t mass;  /* Mass in grams. */
     uint8_t id;    /* The ID of the sensor which reported the measurement. */
 } PACKED mass_p;
 

--- a/pad_server/src/telemetry.h
+++ b/pad_server/src/telemetry.h
@@ -27,6 +27,14 @@ typedef struct {
     char *data_file;
 } telemetry_args_t;
 
+typedef struct {
+    const struct orb_metadata *imu_meta;
+    int imu;
+    long zero_point;       /* Zero point of the sensor */
+    long known_mass_grams; /* Calibration weight in grams */
+    long known_mass_point; /* Calibration weight value */
+} sensor_mass_t;
+
 void *telemetry_run(void *arg);
 void *telemetry_update_padstate(void *arg);
 void telemetry_send_padstate(padstate_t *state, telemetry_sock_t *sock);

--- a/telem_client/src/telem_client_main.c
+++ b/telem_client/src/telem_client_main.c
@@ -118,7 +118,7 @@ int main(int argc, char **argv) {
         case TELEM_MASS: {
             b_read = stream_recv(&telem_stream, &buffer, sizeof(mass_p) + sizeof(hdr));
             mass_p *mass = (mass_p *)&buffer[sizeof(hdr)];
-            printf("Load cell #%u: %u kg @ %u ms\n", mass->id, mass->mass / 1000, mass->time);
+            printf("Load cell #%u: %d kg @ %u ms\n", mass->id, mass->mass / 1000, mass->time);
         } break;
         case TELEM_ACT: {
             b_read = stream_recv(&telem_stream, &buffer, sizeof(act_state_p) + sizeof(hdr));


### PR DESCRIPTION
- Added the NAU7802 loadcell support over UORB
- Added conditional compilation of UORB stuff so that you can still compile without NuttX
- Modified the mass packet so that it's signed instead of unsigned, this is because you can bend the loadcell the other direction and get negative values
- Currently the sensor data is being fetched at a hardcoded interval instead of the poll event, can be changed in the future