### PR TITLE
Switch interrupts

### DIFF
--- a/control_client/Makefile
+++ b/control_client/Makefile
@@ -27,7 +27,7 @@ include $(APPDIR)/Application.mk
 else
 
 CC = gcc
-CFLAGS = -Wall -Wextra
+CFLAGS = -Wall -Wextra -DDESKTOP_BUILD
 OUT = control
 
 SRCDIR = $(abspath ./src)


### PR DESCRIPTION
This PR implements switch interrupts. We have debounced interrupt handling of GPIO pins. Once a switch is toggled, the switch callback associated with it is triggered, sending a message over the network.

This PR's functionality will only work once this PR is merged into the NuttX kernel: https://github.com/apache/nuttx/pull/16281

Closes #54 