### PR TITLE
Keepalive implemented. Currently set to expire after 10 minutes. Only…

### DIFF
--- a/control_client/src/pad.c
+++ b/control_client/src/pad.c
@@ -1,6 +1,7 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <stdint.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -28,7 +29,9 @@ int pad_init(pad_t *pad, const char *ip, uint16_t port) {
     struct timeval tv;
     tv.tv_sec = RCVTIMEO_SEC;
     tv.tv_usec = 0;
-    setsockopt(pad->sock, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof tv);
+    if (setsockopt(pad->sock, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof tv) < 0) {
+        return errno;
+    }
 #endif /* defined(CONFIG_CLOCK_TIMEKEEPING) */
 
     /* Create address */

--- a/pad_server/src/controller.c
+++ b/pad_server/src/controller.c
@@ -65,9 +65,11 @@ static int controller_init(controller_t *controller, uint16_t port) {
     err = setsockopt(controller->sock, IPPROTO_TCP, TCP_KEEPINTVL, &int_secs, sizeof(int));
     if (err < 0) return errno;
 
+#ifndef __APPLE__
     /* Idle `int_secs` before starting to probe with keep-alive ACKS */
     err = setsockopt(controller->sock, IPPROTO_TCP, TCP_KEEPIDLE, &int_secs, sizeof(int));
     if (err < 0) return errno;
+#endif
 
     int count = KEEPALIVE_N_PROBES; /* Gives 10 probes (10 * `int_secs` seconds) to regain connection */
     err = setsockopt(controller->sock, IPPROTO_TCP, TCP_KEEPCNT, &count, sizeof(int));


### PR DESCRIPTION
This PR implements TCP keepalive socket options on the server side.

This works by:
- Sending an ACK message every `KEEPALIVE_INTERVAL_SECS` to the control client
- Repeating this `KEEPALIVE_N_PROBES` times as long there is no response from the control client
- Resetting the connection after all probes fail

This way we can detect a `ECONNRESET` error and trigger the automatic abort sequence.

This was tested by using my Linux host running the pad server and the W5500 running the control client, sending a few commands and then pulling the power on the W5500 to end the control client without sending a FIN packet. I used much smaller interval times for the sake of time.

The connection was successfully reset and the abort message printed.

The keep-alive options for the sockets are compatible across Linux and NuttX, so in theory this should work on both. I will need to verify this once I have a second W5500.