### PR TITLE
Thrust packet

### DIFF
--- a/packets/packet.c
+++ b/packets/packet.c
@@ -50,7 +50,7 @@ void packet_pressure_init(pressure_p *p, uint8_t id, uint32_t time, int32_t pres
     p->pressure = pressure;
 }
 
-void packet_mass_init(mass_p *p, uint8_t id, uint32_t time, uint32_t mass) {
+void packet_mass_init(mass_p *p, uint8_t id, uint32_t time, int32_t mass) {
     p->id = id;
     p->time = time;
     p->mass = mass;

--- a/packets/packet.c
+++ b/packets/packet.c
@@ -56,6 +56,12 @@ void packet_mass_init(mass_p *p, uint8_t id, uint32_t time, int32_t mass) {
     p->mass = mass;
 }
 
+void packet_thrust_init(thrust_p *p, uint8_t id, uint32_t time, uint32_t thrust) {
+    p->id = id;
+    p->time = time;
+    p->thrust = thrust;
+}
+
 void packet_arm_state_init(arm_state_p *p, uint32_t time, arm_lvl_e state) {
     p->time = time;
     p->state = (uint8_t)state;

--- a/packets/packet.h
+++ b/packets/packet.h
@@ -33,10 +33,11 @@ typedef enum {
     TELEM_TEMP = 0,     /* Temperature measurement */
     TELEM_PRESSURE = 1, /* Pressure measurement */
     TELEM_MASS = 2,     /* Mass measurement */
-    TELEM_ARM = 3,      /* Arming state */
-    TELEM_ACT = 4,      /* Actuator state */
-    TELEM_WARN = 5,     /* Warning message */
-    TELEM_CONT = 6,     /* Continuity measurement */
+    TELEM_THRUST = 3,
+    TELEM_ARM = 4,      /* Arming state */
+    TELEM_ACT = 5,      /* Actuator state */
+    TELEM_WARN = 6,     /* Warning message */
+    TELEM_CONT = 7,     /* Continuity measurement */
 } telem_subtype_e;
 
 /* CONTROL MESSAGES */
@@ -110,6 +111,12 @@ typedef struct {
     uint8_t id;    /* The ID of the sensor which reported the measurement. */
 } PACKED mass_p;
 
+typedef struct {
+    uint32_t time; /* Time stamp in milliseconds since power on. */
+    uint32_t thrust; /* Thrust in newtons. */
+    uint8_t id; /* The ID of the sensor which reported the measurement. */
+} PACKED thrust_p;
+
 /* Arming state message */
 typedef struct {
     uint32_t time; /* Time stamp in milliseconds since power on. */
@@ -161,7 +168,8 @@ void packet_arm_ack_init(arm_ack_p *ack, arm_ack_status_e status);
 
 void packet_temp_init(temp_p *p, uint8_t id, uint32_t time, int32_t temperature);
 void packet_pressure_init(pressure_p *p, uint8_t id, uint32_t time, int32_t pressure);
-void packet_mass_init(mass_p *p, uint8_t id, uint32_t time, uint32_t mass);
+void packet_mass_init(mass_p *p, uint8_t id, uint32_t time, int32_t mass);
+void packet_thrust_init(thrust_p *p, uint8_t id, uint32_t time, uint32_t thrust);
 void packet_arm_state_init(arm_state_p *p, uint32_t time, arm_lvl_e state);
 void packet_act_state_init(act_state_p *p, uint8_t id, uint32_t time, bool state);
 void packet_warn_init(warn_p *p, uint32_t time, warn_type_e type);

--- a/packets/packet.h
+++ b/packets/packet.h
@@ -33,7 +33,7 @@ typedef enum {
     TELEM_TEMP = 0,     /* Temperature measurement */
     TELEM_PRESSURE = 1, /* Pressure measurement */
     TELEM_MASS = 2,     /* Mass measurement */
-    TELEM_THRUST = 3,
+    TELEM_THRUST = 3,   /* Thrust measurement */
     TELEM_ARM = 4,      /* Arming state */
     TELEM_ACT = 5,      /* Actuator state */
     TELEM_WARN = 6,     /* Warning message */
@@ -112,9 +112,9 @@ typedef struct {
 } PACKED mass_p;
 
 typedef struct {
-    uint32_t time; /* Time stamp in milliseconds since power on. */
-    uint32_t thrust; /* Thrust in newtons. */
-    uint8_t id; /* The ID of the sensor which reported the measurement. */
+    uint32_t time;   /* Time stamp in milliseconds since power on. */
+    uint32_t thrust; /* Thrust in Newtons. */
+    uint8_t id;      /* The ID of the sensor which reported the measurement. */
 } PACKED thrust_p;
 
 /* Arming state message */

--- a/pad_server/src/telemetry.c
+++ b/pad_server/src/telemetry.c
@@ -405,8 +405,7 @@ static void sensor_telemetry(telemetry_args_t *args, telemetry_sock_t *telem) {
             if (err < 0) {
                 fprintf(stderr, "Error fetching mass data: %d\n", err);
             } else {
-                /* I made the id of this one 3, check on this*/
-                telemetry_publish_data(telem, TELEM_MASS, 3, time_ms, (void *)&sensor_mass.data.force);
+                telemetry_publish_data(telem, TELEM_MASS, 0, time_ms, (void *)&sensor_mass.data.force);
             }
         }
 #endif

--- a/pad_server/src/telemetry.c
+++ b/pad_server/src/telemetry.c
@@ -102,6 +102,7 @@ static void telemetry_publish_data(telemetry_sock_t *sock, telem_subtype_e type,
     pressure_p pressure_body;
     mass_p mass_body;
     temp_p temperature_body;
+    thrust_p thrust_body;
     continuity_state_p continuity_body;
 
     struct iovec pkt[2] = {
@@ -121,7 +122,7 @@ static void telemetry_publish_data(telemetry_sock_t *sock, telem_subtype_e type,
     case TELEM_MASS:
         mass_body.id = id;
         mass_body.time = time;
-        mass_body.mass = deref(uint32_t, data);
+        mass_body.mass = deref(int32_t, data);
         pkt[1].iov_base = &mass_body;
         pkt[1].iov_len = sizeof(mass_body);
         break;
@@ -132,6 +133,14 @@ static void telemetry_publish_data(telemetry_sock_t *sock, telem_subtype_e type,
         temperature_body.temperature = deref(int32_t, data);
         pkt[1].iov_base = &temperature_body;
         pkt[1].iov_len = sizeof(temperature_body);
+        break;
+
+    case TELEM_THRUST:
+        thrust_body.id = id;
+        thrust_body.time = time;
+        thrust_body.thrust = deref(uint32_t, data);
+        pkt[1].iov_base = &thrust_body;
+        pkt[1].iov_len = sizeof(thrust_body);
         break;
 
     case TELEM_CONT:
@@ -340,7 +349,7 @@ static void sensor_telemetry(telemetry_args_t *args, telemetry_sock_t *telem) {
             .n_channels = 2,
             .channels =
                 {
-                    {.channel_num = 4, .sensor_id = 0, .type = TELEM_MASS},
+                    {.channel_num = 4, .sensor_id = 0, .type = TELEM_THRUST},
                     {.channel_num = 6, .sensor_id = 1, .type = TELEM_CONT},
                 },
         },

--- a/pad_server/src/telemetry.c
+++ b/pad_server/src/telemetry.c
@@ -182,30 +182,34 @@ static void random_data(telemetry_sock_t *telem) {
     for (;;) {
 
         pressure = (pressure + 1) % 255;
-        uint32_t pressure_i = 100 + pressure * 10;
+        uint32_t pressure_i = 100 + pressure * 10000;
+        telemetry_publish_data(telem, TELEM_PRESSURE, 0, time, &pressure_i);
+        pressure_i = 200 + pressure * 20000;
         telemetry_publish_data(telem, TELEM_PRESSURE, 1, time, &pressure_i);
-        pressure_i = 200 + pressure * 20;
+        pressure_i = 300 + pressure * 30000;
         telemetry_publish_data(telem, TELEM_PRESSURE, 2, time, &pressure_i);
-        pressure_i = 300 + pressure * 30;
+        pressure_i = 250 + pressure * 40000;
         telemetry_publish_data(telem, TELEM_PRESSURE, 3, time, &pressure_i);
-        pressure_i = 250 + pressure * 40;
+        pressure_i = 250 + pressure * 50000;
         telemetry_publish_data(telem, TELEM_PRESSURE, 4, time, &pressure_i);
+        pressure_i = 250 + pressure * 60000;
+        telemetry_publish_data(telem, TELEM_PRESSURE, 5, time, &pressure_i);
 
         temperature = (temperature + 78) % 20000 + 20000;
         int32_t temp_i = temperature - 1;
-        telemetry_publish_data(telem, TELEM_TEMP, 1, time, &temp_i);
+        telemetry_publish_data(telem, TELEM_TEMP, 0, time, &temp_i);
         temp_i = 2000 + temperature * 2;
-        telemetry_publish_data(telem, TELEM_TEMP, 2, time, &temp_i);
+        telemetry_publish_data(telem, TELEM_TEMP, 1, time, &temp_i);
         temp_i = 3000 + temperature * 3;
-        telemetry_publish_data(telem, TELEM_TEMP, 3, time, &temp_i);
+        telemetry_publish_data(telem, TELEM_TEMP, 2, time, &temp_i);
         temp_i = 2500 + temperature * 4;
-        telemetry_publish_data(telem, TELEM_TEMP, 4, time, &temp_i);
+        telemetry_publish_data(telem, TELEM_TEMP, 3, time, &temp_i);
 
         mass = (mass + 10) % 4000 + 3900;
         uint32_t mass_i = mass + 2;
-        telemetry_publish_data(telem, TELEM_MASS, 1, time, &mass_i);
+        telemetry_publish_data(telem, TELEM_MASS, 0, time, &mass_i);
         mass_i = mass + 4;
-        telemetry_publish_data(telem, TELEM_MASS, 2, time, &mass_i);
+        telemetry_publish_data(telem, TELEM_THRUST, 0, time, &mass_i);
 
         time = (time + 1) % 1000000;
         usleep(100000);


### PR DESCRIPTION
This PR differentiates between mass and thrust as two different packets (the former measuring mass in grams and the latter measuring thrust in newtons).
- Added new thrust packets and associated functions
- Updated random_data function to send data as it would be sent on the real system