### PR TITLE
Read only relevant channels

### DIFF
--- a/pad_server/src/sensors.c
+++ b/pad_server/src/sensors.c
@@ -18,32 +18,6 @@ static double map_value(double value, double in_min, double in_max, double out_m
     return out_min + slope * (value - in_min);
 }
 
-#ifdef CONFIG_ADC_ADS1115
-/*
- * A function to trigger ADC conversion
- * @param adc The ADC device structure
- * @return 0 for success, error code on failure
- */
-int adc_trigger_conversion(adc_device_t *adc) { return ioctl(adc->fd, ANIOC_TRIGGER, 0); }
-
-/*
- * A function to read ADC value after conversion
- * @param adc The ADC device structure
- * @return 0 for success, error code on failure
- */
-int adc_read_value(adc_device_t *adc) {
-    ssize_t nbytes = read(adc->fd, adc->sample, sizeof(adc->sample));
-    if (nbytes < 0) {
-        herr("Failed to read ADC value\n");
-        return nbytes;
-    } else if (nbytes == 0) {
-        return -1;
-    }
-    return OK;
-}
-
-#endif
-
 #ifdef CONFIG_SENSORS_NAU7802
 /* A funcion to fetch the sensor mass data
  * @param sensor_mass The sensor mass object

--- a/pad_server/src/sensors.h
+++ b/pad_server/src/sensors.h
@@ -26,13 +26,10 @@ typedef struct {
     int id;
     int fd;
     const char *devpath;
-    struct adc_msg_s sample[N_ADC_CHANNELS];
     int n_channels;
     adc_channel_t channels[4];
 } adc_device_t;
 
-int adc_read_value(adc_device_t *adc);
-int adc_trigger_conversion(adc_device_t *adc);
 int adc_sensor_val_conversion(adc_channel_t *channel, int32_t adc_val, int32_t *output_val);
 
 #endif


### PR DESCRIPTION
This change reads only the ADC channels which have things connected to them. Testing this change boosts the sampling rate to around 10Hz.