### PR TITLE
parallelizing ads1115 conversion triggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ Make.dep
 .kconfig
 /Kconfig
 *.built
+
+# Dev tools
+compile_commands.json
+.cache/


### PR DESCRIPTION
Instead of looping through the ads1115 I loop through their channels and trigger the value conversion for each one

The result is a 2x speedup of the system, from 10hz to 20hz

This PR will only work with the `ads1115_conversion_trigger` branch on our nuttx fork, until merged